### PR TITLE
Add translation support

### DIFF
--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -1,5 +1,6 @@
 //get current website url 
 const currentUrl = window.location.href;
+const { __ } = wp.i18n;
 
 document.addEventListener("DOMContentLoaded", () => {
   const commandHistory = [];
@@ -18,7 +19,7 @@ document.addEventListener("DOMContentLoaded", () => {
       });
       return Object.keys(pagesMap).map(p => ` - ${p}`).join("<br>");
     } catch {
-      return "Error loading pages.";
+      return __("Error loading pages.", "terminal-theme");
     }
   }
 
@@ -28,7 +29,7 @@ document.addEventListener("DOMContentLoaded", () => {
   async function fetchPosts(page = 1) {
     try {
       const response = await fetch(`/wp-json/wp/v2/posts?per_page=5&page=${page}`);
-      if (!response.ok) throw new Error("Network response was not ok");
+      if (!response.ok) throw new Error(__("Network response was not ok", "terminal-theme"));
       const posts = await response.json();
       blogPage = page;
       blogTotalPages = parseInt(response.headers.get('X-WP-TotalPages')) || 1;
@@ -38,7 +39,7 @@ document.addEventListener("DOMContentLoaded", () => {
         (blogPage > 1 ? `Type <code>blog prev</code> ` : '') +
         (blogPage < blogTotalPages ? `Type <code>blog next</code>` : '');
     } catch (err) {
-      return "Error loading posts: " + err.message;
+      return __("Error loading posts:", "terminal-theme") + " " + err.message;
     }
   }
 
@@ -64,7 +65,7 @@ document.addEventListener("DOMContentLoaded", () => {
         (portfolioPage > 1 ? `Type <code>portfolio prev</code> ` : '') +
         (portfolioPage < portfolioTotalPages ? `Type <code>portfolio next</code>` : '');
     } catch {
-      return "Error loading portfolio.";
+      return __("Error loading portfolio.", "terminal-theme");
     }
   }
 
@@ -75,7 +76,7 @@ document.addEventListener("DOMContentLoaded", () => {
       return cats.map(c => ` - <a href="/category/${c.slug}" target="_blank">${c.name}</a>`).join("<br>");
 
     } catch {
-      return "Error loading categories.";
+      return __("Error loading categories.", "terminal-theme");
     }
   }
 
@@ -89,7 +90,7 @@ document.addEventListener("DOMContentLoaded", () => {
     output.appendChild(loadingSpan);
 
     loadingInterval = setInterval(() => {
-      loadingSpan.textContent = "Loading " + loadingFrames[index];
+      loadingSpan.textContent = __( 'Loading', 'terminal-theme' ) + ' ' + loadingFrames[index];
       index = (index + 1) % loadingFrames.length;
     }, 300);
   }
@@ -130,7 +131,7 @@ document.addEventListener("DOMContentLoaded", () => {
       try {
         if (normalizedCommand === "help") {
           const pagesList = await fetchPages();
-          response = `Available commands:<br> - help<br> - clear<br> - blog<br> - portfolio<br> - categories<br>${pagesList}`;
+          response = `${__( 'Available commands:', 'terminal-theme' )}<br> - help<br> - clear<br> - blog<br> - portfolio<br> - categories<br>${pagesList}`;
         } else if (normalizedCommand === "clear") {
           output.innerHTML = "";
           input.value = "";
@@ -143,21 +144,21 @@ document.addEventListener("DOMContentLoaded", () => {
           if (nextPage <= blogTotalPages) {
             response = await fetchPosts(nextPage);
           } else {
-            response = "You're already on the last page.";
+            response = __("You"."'"."re already on the last page.", "terminal-theme");
           }
         } else if (normalizedCommand === "blog-prev") {
           const prevPage = blogPage - 1;
           if (prevPage >= 1) {
             response = await fetchPosts(prevPage);
           } else {
-            response = "You're already on the first page.";
+            response = __("You"."'"."re already on the first page.", "terminal-theme");
           }
         } else if (normalizedCommand.startsWith("blog-page-")) {
           const pageNum = parseInt(normalizedCommand.replace("blog-page-", ""));
           if (!isNaN(pageNum)) {
             response = await fetchPosts(pageNum);
           } else {
-            response = "Invalid blog page number.";
+            response = __("Invalid blog page number.", "terminal-theme");
           }
         } else if (normalizedCommand === "portfolio") {
           response = await fetchPortfolio(1);
@@ -168,17 +169,17 @@ document.addEventListener("DOMContentLoaded", () => {
           try {
             pageHtml = await fetch(pagesMap[normalizedCommand]).then(res => res.text());
           } catch (e) {
-            pageHtml = "<p>Error loading page.</p>";
+            pageHtml = "<p>" . __("Error loading page.", "terminal-theme") . "</p>";
           }
           let pageDoc = new DOMParser().parseFromString(pageHtml, "text/html");
-          const content = pageDoc.querySelector(".entry-content, .wp-block-post-content")?.innerHTML || "<p>No content found.</p>";
+          const content = pageDoc.querySelector(".entry-content, .wp-block-post-content")?.innerHTML || "<p>" . __("No content found.", "terminal-theme") . "</p>";
           const title = pageDoc.querySelector("h1")?.textContent || command;
           response = `<strong>${title}</strong><br>${content}`;
         } else {
-          response = `Command not found: ${commandRaw}`;
+          response = `${__( 'Command not found:', 'terminal-theme' )} ${commandRaw}`;
         }
       } catch (err) {
-        response = "Error: " + err.message;
+        response = __( 'Error:', 'terminal-theme' ) + ' ' + err.message;
       }
 
       hideLoading();

--- a/functions.php
+++ b/functions.php
@@ -13,8 +13,8 @@ add_action('after_setup_theme', 'terminal_theme_setup');
 add_action('init', function () {
     register_post_type('portfolio', [
         'labels' => [
-            'name' => __('Portfolio'),
-            'singular_name' => __('Portfolio Item'),
+            'name' => __('Portfolio', 'terminal-theme'),
+            'singular_name' => __('Portfolio Item', 'terminal-theme'),
         ],
         'public' => true,
         'has_archive' => true,
@@ -37,7 +37,8 @@ add_action('wp_enqueue_scripts', function () {
 });
 
 add_action('wp_enqueue_scripts', function () {
-    wp_enqueue_script('terminal-js', get_template_directory_uri() . '/assets/js/terminal.js', [], '1.0', true);
+    wp_enqueue_script('terminal-js', get_template_directory_uri() . '/assets/js/terminal.js', ['wp-i18n'], '1.0', true);
+    wp_set_script_translations('terminal-js', 'terminal-theme', get_template_directory() . '/languages');
 });
 
 

--- a/languages/terminal-theme-fa_IR.po
+++ b/languages/terminal-theme-fa_IR.po
@@ -1,0 +1,95 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: terminal-theme 1.0\n"
+"Language: fa_IR\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+
+msgid "Portfolio"
+msgstr "نمونه کارها"
+
+msgid "Portfolio Item"
+msgstr "آیتم نمونه کار"
+
+msgid "Built with WordPress by"
+msgstr "ساخته شده با وردپرس توسط"
+
+msgid "Command Builder"
+msgstr "سازنده فرمان"
+
+msgid "Add custom terminal commands using ACF, theme options, or a future plugin integration."
+msgstr "فرمان‌های ترمینال سفارشی را با استفاده از ACF، گزینه‌های قالب یا افزونه آینده اضافه کنید."
+
+msgid "Command Name:"
+msgstr "نام فرمان:"
+
+msgid "Command Response (HTML/Text):"
+msgstr "پاسخ فرمان (متن/HTML):"
+
+msgid "This form is a mockup — connect it to backend/plugin for saving."
+msgstr "این فرم نمونه است — برای ذخیره‌سازی به افزونه یا بخش پشتی متصل کنید."
+
+msgid "Save Command"
+msgstr "ذخیره فرمان"
+
+msgid "Search"
+msgstr "جستجو"
+
+msgid "Go"
+msgstr "برو"
+
+msgid "Previous"
+msgstr "قبلی"
+
+msgid "Next"
+msgstr "بعدی"
+
+msgid "Type"
+msgstr "بنویسید"
+
+msgid "to list available commands"
+msgstr "برای نمایش دستورات موجود"
+
+msgid "Type command..."
+msgstr "فرمان را بنویسید..."
+
+msgid "Loading"
+msgstr "در حال بارگذاری"
+
+msgid "Available commands:"
+msgstr "دستورات موجود:"
+
+msgid "You're already on the last page."
+msgstr "شما در آخرین صفحه هستید."
+
+msgid "You're already on the first page."
+msgstr "شما در اولین صفحه هستید."
+
+msgid "Invalid blog page number."
+msgstr "شماره صفحه وبلاگ نامعتبر است."
+
+msgid "Error loading pages."
+msgstr "خطا در بارگذاری صفحات."
+
+msgid "Network response was not ok"
+msgstr "پاسخ شبکه مناسب نیست"
+
+msgid "Error loading posts:"
+msgstr "خطا در بارگذاری نوشته‌ها:"
+
+msgid "Error loading portfolio."
+msgstr "خطا در بارگذاری نمونه‌کارها."
+
+msgid "Error loading categories."
+msgstr "خطا در بارگذاری دسته‌بندی‌ها."
+
+msgid "Error loading page."
+msgstr "خطا در بارگذاری صفحه."
+
+msgid "No content found."
+msgstr "محتوایی یافت نشد."
+
+msgid "Command not found:"
+msgstr "فرمان یافت نشد:"
+
+msgid "Error:"
+msgstr "خطا:"

--- a/languages/terminal-theme.pot
+++ b/languages/terminal-theme.pot
@@ -1,0 +1,26 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-07 20:59+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: functions.php:16
+msgid "Portfolio"
+msgstr ""
+
+#: functions.php:17
+msgid "Portfolio Item"
+msgstr ""

--- a/parts/command-builder.html
+++ b/parts/command-builder.html
@@ -1,18 +1,18 @@
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="font-family:'Courier New',monospace;color:#00ff00;">
   <!-- wp:heading -->
-  <h2>Command Builder</h2>
+  <h2><?php echo esc_html__("Command Builder", "terminal-theme"); ?></h2>
   <!-- /wp:heading -->
 
   <!-- wp:paragraph -->
-  <p>Add custom terminal commands using ACF, theme options, or a future plugin integration.</p>
+  <p><?php echo esc_html__("Add custom terminal commands using ACF, theme options, or a future plugin integration.", "terminal-theme"); ?></p>
   <!-- /wp:paragraph -->
 
   <!-- wp:html -->
   <div style="border:1px solid #00ff00;padding:1rem;margin-top:1rem;">
-    <label>Command Name:<br><input type="text" id="cmd-name" style="width:100%; background:black; color:#00ff00; border:1px solid #00ff00;" /></label><br><br>
-    <label>Command Response (HTML/Text):<br><textarea id="cmd-response" style="width:100%;height:100px;background:black;color:#00ff00;border:1px solid #00ff00;"></textarea></label><br><br>
-    <button onclick="alert('This form is a mockup — connect it to backend/plugin for saving.')" style="background:black;color:#00ff00;border:1px solid #00ff00;padding:0.5rem;">Save Command</button>
+    <label><?php echo esc_html__("Command Name:", "terminal-theme"); ?><br><input type="text" id="cmd-name" style="width:100%; background:black; color:#00ff00; border:1px solid #00ff00;" /></label><br><br>
+    <label><?php echo esc_html__("Command Response (HTML/Text):", "terminal-theme"); ?><br><textarea id="cmd-response" style="width:100%;height:100px;background:black;color:#00ff00;border:1px solid #00ff00;"></textarea></label><br><br>
+    <button onclick="alert('<?php echo esc_js( __( 'This form is a mockup — connect it to backend/plugin for saving.', 'terminal-theme' ) ); ?>')" style="background:black;color:#00ff00;border:1px solid #00ff00;padding:0.5rem;"><?php echo esc_html__("Save Command", "terminal-theme"); ?></button>
   </div>
   <!-- /wp:html -->
 </div>

--- a/parts/footer.html
+++ b/parts/footer.html
@@ -1,5 +1,5 @@
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="background-color:#000000;color:#00ff00;padding:1rem;text-align:center;font-family:'Courier New',monospace;">
-  <p>&copy; <script>document.write(new Date().getFullYear())</script> Built with WordPress by <a href="https://whitestudio.team" style="color:#00ff00;text-decoration:underline;" target="_blank">WhiteStudio.team</a></p>
+  <p>&copy; <script>document.write(new Date().getFullYear())</script> <?php echo esc_html__( 'Built with WordPress by', 'terminal-theme' ); ?> <a href="https://whitestudio.team" style="color:#00ff00;text-decoration:underline;" target="_blank">WhiteStudio.team</a></p>
 </div>
 <!-- /wp:group -->

--- a/parts/header.html
+++ b/parts/header.html
@@ -2,6 +2,6 @@
 <div class="wp-block-group terminal-header">
   <!-- wp:site-logo {"width":48} /-->
   <!-- wp:site-title {"level":1,"style":{"typography":{"fontSize":"1.5rem"}}} /-->
-  <!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Go"} /-->
+  <?php echo do_blocks( '<!-- wp:search {"label":"' . esc_attr__( 'Search', 'terminal-theme' ) . '","showLabel":false,"buttonText":"' . esc_html__( 'Go', 'terminal-theme' ) . '"} /-->' ); ?>
 </div>
 <!-- /wp:group -->

--- a/templates/front-page.html
+++ b/templates/front-page.html
@@ -2,13 +2,13 @@
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group test-front-page" style="background-color:#000000;color:#00ff00;font-family:'Courier New',monospace;padding:2rem;">
-  <p><strong>user@terminal:</strong>~$ Type <code>help</code> to list available commands</p>
+  <p><strong>user@terminal:</strong>~$ <?php echo esc_html__( 'Type', 'terminal-theme' ); ?> <code>help</code> <?php echo esc_html__( 'to list available commands', 'terminal-theme' ); ?></p>
 
   <div class="terminal-output" id="terminal-output" style="white-space: pre-wrap;"></div>
 
  <p style="display:flex;align-items:center;">
   <strong>user@terminal:</strong>~$
-  <input id="terminal-input" type="text" autocomplete="off" style="background:none;border:none;color:#00ff00;width:90%; margin:0px 5px" placeholder="Type command..." />
+  <input id="terminal-input" type="text" autocomplete="off" style="background:none;border:none;color:#00ff00;width:90%; margin:0px 5px" placeholder="<?php echo esc_attr__( 'Type command...', 'terminal-theme' ); ?>" />
 </p>
 </div>
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/search.html
+++ b/templates/search.html
@@ -4,7 +4,7 @@
 <div class="wp-block-group" style="background-color:#000000;color:#00ff00;font-family:'Courier New',monospace;padding:2rem;">
 
   <!-- Search Form -->
-  <!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search"} /-->
+  <?php echo do_blocks( '<!-- wp:search {"label":"' . esc_attr__( 'Search', 'terminal-theme' ) . '","showLabel":false,"buttonText":"' . esc_html__( 'Search', 'terminal-theme' ) . '"} /-->' ); ?>
 
   <!-- Search Results -->
   <!-- wp:query -->
@@ -15,9 +15,9 @@
     <!-- /wp:post-template -->
 
     <!-- wp:query-pagination -->
-      <!-- wp:query-pagination-previous {"label":"Previous"} /-->
+      <?php echo do_blocks( '<!-- wp:query-pagination-previous {"label":"' . esc_html__( 'Previous', 'terminal-theme' ) . '"} /-->' ); ?>
       <!-- wp:query-pagination-numbers /-->
-      <!-- wp:query-pagination-next {"label":"Next"} /-->
+      <?php echo do_blocks( '<!-- wp:query-pagination-next {"label":"' . esc_html__( 'Next', 'terminal-theme' ) . '"} /-->' ); ?>
     <!-- /wp:query-pagination -->
   </div>
   <!-- /wp:query -->


### PR DESCRIPTION
## Summary
- make strings translatable using `terminal-theme` domain
- add Farsi translation file
- load script translations and update JS strings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844a710fc348326aba1570ed522a009