### PR TITLE
Add i18n support for templates and JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A minimal, terminal-style WordPress theme designed for developers, hackers, and 
 - **Terminal Look & Feel**: Styled to resemble a terminal window with a dark, hacker-like aesthetic.
 - **Minimal and Clean**: Lightweight design focused on readability and performance.
 - **Responsive Design**: Fully responsive layout that works great on all devices.
+- **FSE (Full Site Editing) Support**: Built as a block theme for WordPress's Full Site Editing system.
 - **Custom Menu Support**: Add your own menu items through the WordPress dashboard.
 - **Widget Support**: Footer and sidebar widgets supported.
 - **Syntax Highlighting**: Built-in support for code snippets using Prism.js or similar libraries.
@@ -52,6 +53,18 @@ Select **Terminal Theme** and click **Activate**.
 - Use the Customizer to update site title, tagline, and menu.
 - Add your own CSS in `style.css` or via WordPress Customizer.
 - Customize the layout via `index.php`, `header.php`, `footer.php`, and other template files.
+
+## Localization
+
+If you want to translate the theme, use WordPress's `wp i18n` command to generate
+or update the POT file. This extracts strings from PHP, HTML, and JavaScript files:
+
+```bash
+wp i18n make-pot . languages/terminal-theme.pot \
+  --include="templates/**,parts/**,assets/js/**"
+```
+
+Add your translations in the `languages` folder using standard `.po` files.
 
 ---
 

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -1,4 +1,6 @@
-//get current website url 
+import { __, sprintf } from '@wordpress/i18n';
+
+//get current website url
 const currentUrl = window.location.href;
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -18,7 +20,7 @@ document.addEventListener("DOMContentLoaded", () => {
       });
       return Object.keys(pagesMap).map(p => ` - ${p}`).join("<br>");
     } catch {
-      return "Error loading pages.";
+      return __( 'Error loading pages.', 'terminal-theme' );
     }
   }
 
@@ -28,17 +30,17 @@ document.addEventListener("DOMContentLoaded", () => {
   async function fetchPosts(page = 1) {
     try {
       const response = await fetch(`/wp-json/wp/v2/posts?per_page=5&page=${page}`);
-      if (!response.ok) throw new Error("Network response was not ok");
+      if (!response.ok) throw new Error( __( 'Network response was not ok', 'terminal-theme' ) );
       const posts = await response.json();
       blogPage = page;
       blogTotalPages = parseInt(response.headers.get('X-WP-TotalPages')) || 1;
 
       return posts.map(p => ` - <a href="${p.link}" target="_blank">${p.title.rendered}</a>`).join("<br>") +
-        `<br><br>Page ${blogPage} of ${blogTotalPages}<br>` +
-        (blogPage > 1 ? `Type <code>blog prev</code> ` : '') +
-        (blogPage < blogTotalPages ? `Type <code>blog next</code>` : '');
+        `<br><br>${sprintf( __( 'Page %1$d of %2$d', 'terminal-theme' ), blogPage, blogTotalPages )}<br>` +
+        (blogPage > 1 ? sprintf( __( 'Type %s', 'terminal-theme' ), '<code>blog prev</code> ' ) : '') +
+        (blogPage < blogTotalPages ? sprintf( __( 'Type %s', 'terminal-theme' ), '<code>blog next</code>' ) : '');
     } catch (err) {
-      return "Error loading posts: " + err.message;
+      return __( 'Error loading posts:', 'terminal-theme' ) + ' ' + err.message;
     }
   }
 
@@ -60,11 +62,11 @@ document.addEventListener("DOMContentLoaded", () => {
           <a href="${pfLink}" target="_blank"><strong>${pfTitle}</strong></a><br>${pfDescription}
         </div>`;
       }).join("<br>") +
-        `<br><br>Page ${portfolioPage} of ${portfolioTotalPages}<br>` +
-        (portfolioPage > 1 ? `Type <code>portfolio prev</code> ` : '') +
-        (portfolioPage < portfolioTotalPages ? `Type <code>portfolio next</code>` : '');
+        `<br><br>${sprintf( __( 'Page %1$d of %2$d', 'terminal-theme' ), portfolioPage, portfolioTotalPages )}<br>` +
+        (portfolioPage > 1 ? sprintf( __( 'Type %s', 'terminal-theme' ), '<code>portfolio prev</code> ' ) : '') +
+        (portfolioPage < portfolioTotalPages ? sprintf( __( 'Type %s', 'terminal-theme' ), '<code>portfolio next</code>' ) : '');
     } catch {
-      return "Error loading portfolio.";
+      return __( 'Error loading portfolio.', 'terminal-theme' );
     }
   }
 
@@ -75,7 +77,7 @@ document.addEventListener("DOMContentLoaded", () => {
       return cats.map(c => ` - <a href="/category/${c.slug}" target="_blank">${c.name}</a>`).join("<br>");
 
     } catch {
-      return "Error loading categories.";
+      return __( 'Error loading categories.', 'terminal-theme' );
     }
   }
 
@@ -89,7 +91,7 @@ document.addEventListener("DOMContentLoaded", () => {
     output.appendChild(loadingSpan);
 
     loadingInterval = setInterval(() => {
-      loadingSpan.textContent = "Loading " + loadingFrames[index];
+      loadingSpan.textContent = __( 'Loading', 'terminal-theme' ) + ' ' + loadingFrames[index];
       index = (index + 1) % loadingFrames.length;
     }, 300);
   }
@@ -130,7 +132,7 @@ document.addEventListener("DOMContentLoaded", () => {
       try {
         if (normalizedCommand === "help") {
           const pagesList = await fetchPages();
-          response = `Available commands:<br> - help<br> - clear<br> - blog<br> - portfolio<br> - categories<br>${pagesList}`;
+          response = `${ __( 'Available commands:', 'terminal-theme' ) }<br> - help<br> - clear<br> - blog<br> - portfolio<br> - categories<br>${pagesList}`;
         } else if (normalizedCommand === "clear") {
           output.innerHTML = "";
           input.value = "";
@@ -143,21 +145,21 @@ document.addEventListener("DOMContentLoaded", () => {
           if (nextPage <= blogTotalPages) {
             response = await fetchPosts(nextPage);
           } else {
-            response = "You're already on the last page.";
+            response = __( "You're already on the last page.", 'terminal-theme' );
           }
         } else if (normalizedCommand === "blog-prev") {
           const prevPage = blogPage - 1;
           if (prevPage >= 1) {
             response = await fetchPosts(prevPage);
           } else {
-            response = "You're already on the first page.";
+            response = __( "You're already on the first page.", 'terminal-theme' );
           }
         } else if (normalizedCommand.startsWith("blog-page-")) {
           const pageNum = parseInt(normalizedCommand.replace("blog-page-", ""));
           if (!isNaN(pageNum)) {
             response = await fetchPosts(pageNum);
           } else {
-            response = "Invalid blog page number.";
+            response = __( 'Invalid blog page number.', 'terminal-theme' );
           }
         } else if (normalizedCommand === "portfolio") {
           response = await fetchPortfolio(1);
@@ -168,17 +170,17 @@ document.addEventListener("DOMContentLoaded", () => {
           try {
             pageHtml = await fetch(pagesMap[normalizedCommand]).then(res => res.text());
           } catch (e) {
-            pageHtml = "<p>Error loading page.</p>";
+            pageHtml = `<p>${ __( 'Error loading page.', 'terminal-theme' ) }</p>`;
           }
           let pageDoc = new DOMParser().parseFromString(pageHtml, "text/html");
-          const content = pageDoc.querySelector(".entry-content, .wp-block-post-content")?.innerHTML || "<p>No content found.</p>";
+          const content = pageDoc.querySelector(".entry-content, .wp-block-post-content")?.innerHTML || `<p>${ __( 'No content found.', 'terminal-theme' ) }</p>`;
           const title = pageDoc.querySelector("h1")?.textContent || command;
           response = `<strong>${title}</strong><br>${content}`;
         } else {
-          response = `Command not found: ${commandRaw}`;
+          response = sprintf( __( 'Command not found: %s', 'terminal-theme' ), commandRaw );
         }
       } catch (err) {
-        response = "Error: " + err.message;
+        response = __( 'Error:', 'terminal-theme' ) + ' ' + err.message;
       }
 
       hideLoading();

--- a/functions.php
+++ b/functions.php
@@ -13,8 +13,8 @@ add_action('after_setup_theme', 'terminal_theme_setup');
 add_action('init', function () {
     register_post_type('portfolio', [
         'labels' => [
-            'name' => __('Portfolio'),
-            'singular_name' => __('Portfolio Item'),
+            'name' => __('Portfolio', 'terminal-theme'),
+            'singular_name' => __('Portfolio Item', 'terminal-theme'),
         ],
         'public' => true,
         'has_archive' => true,
@@ -37,7 +37,7 @@ add_action('wp_enqueue_scripts', function () {
 });
 
 add_action('wp_enqueue_scripts', function () {
-    wp_enqueue_script('terminal-js', get_template_directory_uri() . '/assets/js/terminal.js', [], '1.0', true);
+    wp_enqueue_script('terminal-js', get_template_directory_uri() . '/assets/js/terminal.js', ['wp-i18n'], '1.0', true);
 });
 
 

--- a/languages/terminal-theme-en_US.po
+++ b/languages/terminal-theme-en_US.po
@@ -1,0 +1,92 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: terminal-theme 1.0\n"
+"Language: en_US\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+
+msgid "Portfolio"
+msgstr "Portfolio"
+
+msgid "Portfolio Item"
+msgstr "Portfolio Item"
+
+msgid "FSE"
+msgstr "Full Site Editing"
+
+msgid "Search"
+msgstr "Search"
+
+msgid "Go"
+msgstr "Go"
+
+msgid "Type <code>help</code> to list available commands"
+msgstr "Type <code>help</code> to list available commands"
+
+msgid "Type command..."
+msgstr "Type command..."
+
+msgid "Command Builder"
+msgstr "Command Builder"
+
+msgid "Add custom terminal commands using ACF, theme options, or a future plugin integration."
+msgstr "Add custom terminal commands using ACF, theme options, or a future plugin integration."
+
+msgid "Command Name:"
+msgstr "Command Name:"
+
+msgid "Command Response (HTML/Text):"
+msgstr "Command Response (HTML/Text):"
+
+msgid "This form is a mockup — connect it to backend/plugin for saving."
+msgstr "This form is a mockup — connect it to backend/plugin for saving."
+
+msgid "Save Command"
+msgstr "Save Command"
+
+msgid "Error loading pages."
+msgstr "Error loading pages."
+
+msgid "Network response was not ok"
+msgstr "Network response was not ok"
+
+msgid "Error loading posts:"
+msgstr "Error loading posts:"
+
+msgid "Error loading portfolio."
+msgstr "Error loading portfolio."
+
+msgid "Error loading categories."
+msgstr "Error loading categories."
+
+msgid "Loading"
+msgstr "Loading"
+
+msgid "Available commands:"
+msgstr "Available commands:"
+
+msgid "You're already on the last page."
+msgstr "You're already on the last page."
+
+msgid "You're already on the first page."
+msgstr "You're already on the first page."
+
+msgid "Invalid blog page number."
+msgstr "Invalid blog page number."
+
+msgid "Error loading page."
+msgstr "Error loading page."
+
+msgid "No content found."
+msgstr "No content found."
+
+msgid "Command not found: %s"
+msgstr "Command not found: %s"
+
+msgid "Error:"
+msgstr "Error:"
+
+msgid "Page %1$d of %2$d"
+msgstr "Page %1$d of %2$d"
+
+msgid "Type %s"
+msgstr "Type %s"

--- a/parts/command-builder.html
+++ b/parts/command-builder.html
@@ -1,18 +1,18 @@
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="font-family:'Courier New',monospace;color:#00ff00;">
   <!-- wp:heading -->
-  <h2>Command Builder</h2>
+  <h2>{{ __( 'Command Builder', 'terminal-theme' ) }}</h2>
   <!-- /wp:heading -->
 
   <!-- wp:paragraph -->
-  <p>Add custom terminal commands using ACF, theme options, or a future plugin integration.</p>
+  <p>{{ __( 'Add custom terminal commands using ACF, theme options, or a future plugin integration.', 'terminal-theme' ) }}</p>
   <!-- /wp:paragraph -->
 
   <!-- wp:html -->
   <div style="border:1px solid #00ff00;padding:1rem;margin-top:1rem;">
-    <label>Command Name:<br><input type="text" id="cmd-name" style="width:100%; background:black; color:#00ff00; border:1px solid #00ff00;" /></label><br><br>
-    <label>Command Response (HTML/Text):<br><textarea id="cmd-response" style="width:100%;height:100px;background:black;color:#00ff00;border:1px solid #00ff00;"></textarea></label><br><br>
-    <button onclick="alert('This form is a mockup — connect it to backend/plugin for saving.')" style="background:black;color:#00ff00;border:1px solid #00ff00;padding:0.5rem;">Save Command</button>
+    <label>{{ __( 'Command Name:', 'terminal-theme' ) }}<br><input type="text" id="cmd-name" style="width:100%; background:black; color:#00ff00; border:1px solid #00ff00;" /></label><br><br>
+    <label>{{ __( 'Command Response (HTML/Text):', 'terminal-theme' ) }}<br><textarea id="cmd-response" style="width:100%;height:100px;background:black;color:#00ff00;border:1px solid #00ff00;"></textarea></label><br><br>
+    <button onclick="alert('{{ __( 'This form is a mockup — connect it to backend/plugin for saving.', 'terminal-theme' ) }}')" style="background:black;color:#00ff00;border:1px solid #00ff00;padding:0.5rem;">{{ __( 'Save Command', 'terminal-theme' ) }}</button>
   </div>
   <!-- /wp:html -->
 </div>

--- a/parts/header.html
+++ b/parts/header.html
@@ -2,6 +2,6 @@
 <div class="wp-block-group terminal-header">
   <!-- wp:site-logo {"width":48} /-->
   <!-- wp:site-title {"level":1,"style":{"typography":{"fontSize":"1.5rem"}}} /-->
-  <!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Go"} /-->
+  <!-- wp:search {"label":"{{ __( 'Search', 'terminal-theme' ) }}","showLabel":false,"buttonText":"{{ __( 'Go', 'terminal-theme' ) }}"} /-->
 </div>
 <!-- /wp:group -->

--- a/templates/front-page.html
+++ b/templates/front-page.html
@@ -2,13 +2,13 @@
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group test-front-page" style="background-color:#000000;color:#00ff00;font-family:'Courier New',monospace;padding:2rem;">
-  <p><strong>user@terminal:</strong>~$ Type <code>help</code> to list available commands</p>
+  <p><strong>user@terminal:</strong>~$ {{ __( 'Type <code>help</code> to list available commands', 'terminal-theme' ) }}</p>
 
   <div class="terminal-output" id="terminal-output" style="white-space: pre-wrap;"></div>
 
  <p style="display:flex;align-items:center;">
   <strong>user@terminal:</strong>~$
-  <input id="terminal-input" type="text" autocomplete="off" style="background:none;border:none;color:#00ff00;width:90%; margin:0px 5px" placeholder="Type command..." />
+  <input id="terminal-input" type="text" autocomplete="off" style="background:none;border:none;color:#00ff00;width:90%; margin:0px 5px" placeholder="{{ __( 'Type command...', 'terminal-theme' ) }}" />
 </p>
 </div>
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->


### PR DESCRIPTION
## Summary
- localize strings in HTML templates using `{{ __() }}` syntax
- use wp-i18n in JS and add translations for dynamic messages
- pass text domain to PHP translation calls and enqueue wp-i18n script
- expand sample `.po` file with new strings

## Testing
- `npm test` *(fails: could not find package.json)*

