### PR TITLE
Enable theme-wide color customization

### DIFF
--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -8,7 +8,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const output = document.getElementById("terminal-output");
   const pagesMap = {};
 
-  async function fetchPages() {
+  async function whitestudioteam_fetchPages() {
     try {
       const response = await fetch(currentUrl + '/wp-json/wp/v2/pages?per_page=100');
       const pages = await response.json();
@@ -25,7 +25,7 @@ document.addEventListener("DOMContentLoaded", () => {
   let blogPage = 1;
   let blogTotalPages = 1;
 
-  async function fetchPosts(page = 1) {
+  async function whitestudioteam_fetchPosts(page = 1) {
     try {
       const response = await fetch(`/wp-json/wp/v2/posts?per_page=5&page=${page}`);
       if (!response.ok) throw new Error("Network response was not ok");
@@ -45,7 +45,7 @@ document.addEventListener("DOMContentLoaded", () => {
   let portfolioPage = 1;
   let portfolioTotalPages = 1;
 
-  async function fetchPortfolio(page = 1) {
+  async function whitestudioteam_fetchPortfolio(page = 1) {
     try {
       const response = await fetch(`/wp-json/wp/v2/portfolio?per_page=5&page=${page}`);
       const items = await response.json();
@@ -68,7 +68,7 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   }
 
-  async function fetchCategories() {
+  async function whitestudioteam_fetchCategories() {
     try {
       const response = await fetch(currentUrl + '/wp-json/wp/v2/categories');
       const cats = await response.json();
@@ -81,7 +81,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // 🔄 Loading Animation
   let loadingInterval;
-  function showLoading() {
+  function whitestudioteam_showLoading() {
     const loadingFrames = [".", ". .", ". . .", ". .", "."];
     let index = 0;
     const loadingSpan = document.createElement("span");
@@ -94,7 +94,7 @@ document.addEventListener("DOMContentLoaded", () => {
     }, 300);
   }
 
-  function hideLoading() {
+  function whitestudioteam_hideLoading() {
     clearInterval(loadingInterval);
     const loadingSpan = document.getElementById("loading");
     if (loadingSpan) loadingSpan.remove();
@@ -125,44 +125,44 @@ document.addEventListener("DOMContentLoaded", () => {
       const normalizedCommand = command.replace(/\s+/g, '-');
       let response = "";
 
-      showLoading();
+      whitestudioteam_showLoading();
 
       try {
         if (normalizedCommand === "help") {
-          const pagesList = await fetchPages();
+          const pagesList = await whitestudioteam_fetchPages();
           response = `Available commands:<br> - help<br> - clear<br> - blog<br> - portfolio<br> - categories<br>${pagesList}`;
         } else if (normalizedCommand === "clear") {
           output.innerHTML = "";
           input.value = "";
-          hideLoading();
+          whitestudioteam_hideLoading();
           return;
         } else if (normalizedCommand === "blog") {
-          response = await fetchPosts(1);
+          response = await whitestudioteam_fetchPosts(1);
         } else if (normalizedCommand === "blog-next") {
           const nextPage = blogPage + 1;
           if (nextPage <= blogTotalPages) {
-            response = await fetchPosts(nextPage);
+            response = await whitestudioteam_fetchPosts(nextPage);
           } else {
             response = "You're already on the last page.";
           }
         } else if (normalizedCommand === "blog-prev") {
           const prevPage = blogPage - 1;
           if (prevPage >= 1) {
-            response = await fetchPosts(prevPage);
+            response = await whitestudioteam_fetchPosts(prevPage);
           } else {
             response = "You're already on the first page.";
           }
         } else if (normalizedCommand.startsWith("blog-page-")) {
           const pageNum = parseInt(normalizedCommand.replace("blog-page-", ""));
           if (!isNaN(pageNum)) {
-            response = await fetchPosts(pageNum);
+            response = await whitestudioteam_fetchPosts(pageNum);
           } else {
             response = "Invalid blog page number.";
           }
         } else if (normalizedCommand === "portfolio") {
-          response = await fetchPortfolio(1);
+          response = await whitestudioteam_fetchPortfolio(1);
         } else if (normalizedCommand === "categories") {
-          response = await fetchCategories();
+          response = await whitestudioteam_fetchCategories();
         } else if (pagesMap[normalizedCommand]) {
           let pageHtml = "";
           try {
@@ -181,7 +181,7 @@ document.addEventListener("DOMContentLoaded", () => {
         response = "Error: " + err.message;
       }
 
-      hideLoading();
+      whitestudioteam_hideLoading();
 
       const fullResponse = `<br><strong>user@terminal:</strong>~$ ${commandRaw}<br>${response}`;
       const tempDiv = document.createElement("div");
@@ -225,5 +225,17 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
-  fetchPages();
+  whitestudioteam_fetchPages();
+
+  const yearSpan = document.getElementById("whitestudioteam-year");
+  if (yearSpan) {
+    yearSpan.textContent = new Date().getFullYear();
+  }
+
+  const saveBtn = document.getElementById("whitestudioteam-save-command");
+  if (saveBtn) {
+    saveBtn.addEventListener("click", () => {
+      alert('This form is a mockup — connect it to backend/plugin for saving.');
+    });
+  }
 });

--- a/functions.php
+++ b/functions.php
@@ -1,13 +1,13 @@
 <?php
-function terminal_theme_enqueue_styles() {
-    wp_enqueue_style('terminal-style', get_stylesheet_directory_uri() . '/style.css', [], wp_get_theme()->get('Version'));
+function whitestudioteam_enqueue_styles() {
+    wp_enqueue_style('whitestudioteam_terminal-style', get_stylesheet_directory_uri() . '/style.css', [], wp_get_theme()->get('Version'));
 }
-add_action('wp_enqueue_scripts', 'terminal_theme_enqueue_styles');
-function terminal_theme_setup() {
+add_action('wp_enqueue_scripts', 'whitestudioteam_enqueue_styles');
+function whitestudioteam_setup() {
     add_theme_support('editor-styles');
     add_editor_style('style.css');
 }
-add_action('after_setup_theme', 'terminal_theme_setup');
+add_action('after_setup_theme', 'whitestudioteam_setup');
 
 
 add_action('init', function () {
@@ -32,17 +32,17 @@ add_action('after_setup_theme', function () {
 
 add_action('wp_enqueue_scripts', function () {
     if (function_exists('wpcf7_enqueue_scripts')) {
-        wp_enqueue_style('terminal-cf7', get_template_directory_uri() . '/assets/css/terminal-cf7.css', [], '1.0');
+        wp_enqueue_style('whitestudioteam_terminal-cf7', get_template_directory_uri() . '/assets/css/terminal-cf7.css', [], '1.0');
     }
 });
 
 add_action('wp_enqueue_scripts', function () {
-    wp_enqueue_script('terminal-js', get_template_directory_uri() . '/assets/js/terminal.js', [], '1.0', true);
+    wp_enqueue_script('whitestudioteam_terminal-js', get_template_directory_uri() . '/assets/js/terminal.js', [], '1.0', true);
 });
 
 
 add_filter('script_loader_tag', function($tag, $handle, $src) {
-    if ($handle === 'terminal-js') {
+    if ($handle === 'whitestudioteam_terminal-js') {
         return '<script type="module" src="' . esc_url($src) . '"></script>';
     }
     return $tag;

--- a/parts/command-builder.html
+++ b/parts/command-builder.html
@@ -1,5 +1,5 @@
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="font-family:'Courier New',monospace;color:#00ff00;">
+<div class="wp-block-group whitestudioteam-terminal">
   <!-- wp:heading -->
   <h2>Command Builder</h2>
   <!-- /wp:heading -->
@@ -9,10 +9,10 @@
   <!-- /wp:paragraph -->
 
   <!-- wp:html -->
-  <div style="border:1px solid #00ff00;padding:1rem;margin-top:1rem;">
-    <label>Command Name:<br><input type="text" id="cmd-name" style="width:100%; background:black; color:#00ff00; border:1px solid #00ff00;" /></label><br><br>
-    <label>Command Response (HTML/Text):<br><textarea id="cmd-response" style="width:100%;height:100px;background:black;color:#00ff00;border:1px solid #00ff00;"></textarea></label><br><br>
-    <button onclick="alert('This form is a mockup — connect it to backend/plugin for saving.')" style="background:black;color:#00ff00;border:1px solid #00ff00;padding:0.5rem;">Save Command</button>
+  <div class="whitestudioteam-command-builder">
+    <label>Command Name:<br><input type="text" id="cmd-name" /></label><br><br>
+    <label>Command Response (HTML/Text):<br><textarea id="cmd-response"></textarea></label><br><br>
+    <button id="whitestudioteam-save-command">Save Command</button>
   </div>
   <!-- /wp:html -->
 </div>

--- a/parts/footer.html
+++ b/parts/footer.html
@@ -1,5 +1,5 @@
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="background-color:#000000;color:#00ff00;padding:1rem;text-align:center;font-family:'Courier New',monospace;">
-  <p>&copy; <script>document.write(new Date().getFullYear())</script> Built with WordPress by <a href="https://whitestudio.team" style="color:#00ff00;text-decoration:underline;" target="_blank">WhiteStudio.team</a></p>
+<div class="wp-block-group whitestudioteam-terminal whitestudioteam-footer">
+  <p>&copy; <span id="whitestudioteam-year"></span> Built with WordPress by <a href="https://whitestudio.team" target="_blank">WhiteStudio.team</a></p>
 </div>
 <!-- /wp:group -->

--- a/parts/header.html
+++ b/parts/header.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between"},"style":{"color":{"text":"#00ff00"},"spacing":{"padding":{"top":"1rem","bottom":"1rem","left":"1rem","right":"1rem"}}}} -->
+<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between"}} -->
 <div class="wp-block-group terminal-header">
   <!-- wp:site-logo {"width":48} /-->
   <!-- wp:site-title {"level":1,"style":{"typography":{"fontSize":"1.5rem"}}} /-->

--- a/style.css
+++ b/style.css
@@ -14,17 +14,25 @@ Text Domain: terminal-theme
 Tags: full-site-editing, block-theme, dark-mode, green-text, terminal
 */
 
+:root {
+  --whitestudioteam-bg: #000000;
+  --whitestudioteam-text: #00ff00;
+}
+
 /* Terminal comment styling */
 .wp-block-comments,
 .comment-body,
 .comment-content,
 .comment-author {
   font-family: 'Courier New', monospace;
-  background: #000;
-  color: #00ff00;
-  border: 1px solid #00ff00;
+  background: var(--whitestudioteam-bg);
+  color: var(--whitestudioteam-text);
+  border: 1px solid var(--whitestudioteam-text);
   padding: 1rem;
   margin-top: 1rem;
+}
+.wp-block-comments {
+  margin-top: 3rem;
 }
 
 img {
@@ -32,13 +40,31 @@ img {
   height: auto;
   display: block;
 }
+
+.whitestudioteam-grayscale-img {
+  filter: grayscale(100%) contrast(120%);
+  transition: all 0.3s ease;
+}
+.whitestudioteam-grayscale-img:hover {
+  filter: none;
+  box-shadow: 0 0 10px var(--whitestudioteam-text);
+}
+
+.whitestudioteam-page img {
+  filter: grayscale(100%) contrast(120%);
+  transition: all 0.3s ease;
+}
+.whitestudioteam-page img:hover {
+  filter: none;
+  box-shadow: 0 0 10px var(--whitestudioteam-text);
+}
 /* ================================
    Terminal Header & Search (Styled)
    ================================ */
 
 .terminal-header {
-  background-color: #000000;
-  color: #00ff00;
+  background-color: var(--whitestudioteam-bg);
+  color: var(--whitestudioteam-text);
   font-family: 'Courier New', monospace;
   display: flex;
   justify-content: space-between;
@@ -50,7 +76,7 @@ img {
 
 /* Site title link */
 .wp-block-site-title a {
-  color: #00ff00;
+  color: var(--whitestudioteam-text);
   font-weight: bold;
   text-decoration: none;
   font-size: 1.25rem;
@@ -63,9 +89,9 @@ img {
 
 /* Search input field */
 .wp-block-search__input {
-  background-color: #000000;
+  background-color: var(--whitestudioteam-bg);
   border: 1px solid #444;
-  color: #00ff00;
+  color: var(--whitestudioteam-text);
   padding: 0.4rem 0.6rem;
   font-family: 'Courier New', monospace;
   font-size: 0.9rem;
@@ -73,14 +99,14 @@ img {
 }
 .wp-block-search__input:focus {
   outline: none;
-  border-color: #00ff00;
-  box-shadow: 0 0 5px #00ff00;
+  border-color: var(--whitestudioteam-text);
+  box-shadow: 0 0 5px var(--whitestudioteam-text);
 }
 
 /* Search button */
 .wp-block-search__button {
-  background-color: #000000;
-  color: #00ff00;
+  background-color: var(--whitestudioteam-bg);
+  color: var(--whitestudioteam-text);
   border: 1px solid #444;
   padding: 0.4rem 0.8rem;
   font-family: 'Courier New', monospace;
@@ -89,9 +115,9 @@ img {
   transition: all 0.2s ease-in-out;
 }
 .wp-block-search__button:hover {
-  background-color: #00ff00;
-  color: #000000;
-  border-color: #00ff00;
+  background-color: var(--whitestudioteam-text);
+  color: var(--whitestudioteam-bg);
+  border-color: var(--whitestudioteam-text);
 }
 
 /* Responsive: Stack on small screens */
@@ -118,9 +144,48 @@ img {
 /* ========== Terminal Theme Colors ========== */
 
 body {
-  background-color: #000000;
+  background-color: var(--whitestudioteam-bg);
   color: #cccccc;
   font-family: 'Courier New', monospace;
+}
+
+/* Shared terminal section */
+.whitestudioteam-terminal {
+  background-color: var(--whitestudioteam-bg);
+  color: var(--whitestudioteam-text);
+  font-family: 'Courier New', monospace;
+  padding: 2rem;
+}
+
+.whitestudioteam-input-wrapper {
+  display: flex;
+  align-items: center;
+}
+
+.whitestudioteam-command-builder {
+  border: 1px solid var(--whitestudioteam-text);
+  padding: 1rem;
+  margin-top: 1rem;
+}
+
+.whitestudioteam-command-builder input,
+.whitestudioteam-command-builder textarea {
+  width: 100%;
+  background: var(--whitestudioteam-bg);
+  color: var(--whitestudioteam-text);
+  border: 1px solid var(--whitestudioteam-text);
+}
+
+.whitestudioteam-command-builder button {
+  background: var(--whitestudioteam-bg);
+  color: var(--whitestudioteam-text);
+  border: 1px solid var(--whitestudioteam-text);
+  padding: 0.5rem;
+}
+
+.whitestudioteam-footer {
+  padding: 1rem;
+  text-align: center;
 }
 
 /* Terminal container */
@@ -132,7 +197,7 @@ body {
 
 /* Prompt */
 .terminal-prompt {
-  color: #00ff00;
+  color: var(--whitestudioteam-text);
   font-weight: bold;
 }
 
@@ -157,9 +222,9 @@ body {
 
 /* Input field styling */
 #terminal-input {
-  background-color: #000000;
+  background-color: var(--whitestudioteam-bg);
   border: none;
-  color: #aaaaaa;
+  color: var(--whitestudioteam-text);
   font-family: 'Courier New', monospace;
   width: 90%;
   outline: none;
@@ -172,7 +237,7 @@ body {
 
 /* Link styling */
 a {
-  color: #f5c542;
+  color: var(--whitestudioteam-text);
   text-decoration: none;
 }
 a:hover {

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="background-color:#000000;color:#00ff00;font-family:'Courier New',monospace;padding:2rem;">
+<div class="wp-block-group whitestudioteam-terminal">
   <!-- wp:query-title {"type":"archive"} /-->
 
   <!-- wp:query {"queryId":0,"query":{"perPage":5,"pages":0,"offset":0,"postType":"post"},"displayLayout":{"type":"list"},"tagName":"div"} -->

--- a/templates/front-page.html
+++ b/templates/front-page.html
@@ -1,14 +1,14 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group test-front-page" style="background-color:#000000;color:#00ff00;font-family:'Courier New',monospace;padding:2rem;">
+<div class="wp-block-group whitestudioteam-terminal">
   <p><strong>user@terminal:</strong>~$ Type <code>help</code> to list available commands</p>
 
-  <div class="terminal-output" id="terminal-output" style="white-space: pre-wrap;"></div>
+  <div class="terminal-output" id="terminal-output"></div>
 
- <p style="display:flex;align-items:center;">
+ <p class="whitestudioteam-input-wrapper">
   <strong>user@terminal:</strong>~$
-  <input id="terminal-input" type="text" autocomplete="off" style="background:none;border:none;color:#00ff00;width:90%; margin:0px 5px" placeholder="Type command..." />
+  <input id="terminal-input" type="text" autocomplete="off" placeholder="Type command..." />
 </p>
 </div>
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,18 +1,8 @@
 
-<style>
-img {
-  filter: grayscale(100%) contrast(120%);
-  transition: all 0.3s ease;
-}
-img:hover {
-  filter: none;
-  box-shadow: 0 0 10px #00ff00;
-}
-</style>
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group test-page" style="background-color:#000000;color:#00ff00;font-family:'Courier New',monospace;padding:2rem;">
+<div class="wp-block-group whitestudioteam-terminal whitestudioteam-page">
   <!-- wp:post-title /-->
   <!-- wp:post-content /-->
 </div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="background-color:#000000;color:#00ff00;font-family:'Courier New',monospace;padding:2rem;">
+<div class="wp-block-group whitestudioteam-terminal">
 
   <!-- Search Form -->
   <!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search"} /-->

--- a/templates/single.html
+++ b/templates/single.html
@@ -1,23 +1,13 @@
 
-<style>
-.comment-body, .comment-author, .comment-content {
-  font-family: 'Courier New', monospace;
-  background-color: black;
-  color: #00ff00;
-  border: 1px solid #00ff00;
-  padding: 0.5rem;
-  margin-bottom: 1rem;
-}
-</style>
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="background-color:#000000;color:#00ff00;font-family:'Courier New',monospace;padding:2rem;">
+<div class="wp-block-group whitestudioteam-terminal">
   <!-- wp:post-title /-->
   <!-- wp:post-content /-->
 
   <!-- wp:comments -->
-  <div class="wp-block-comments" style="margin-top: 3rem;">
+  <div class="wp-block-comments">
     <!-- wp:comments-title /-->
     <!-- wp:comment-template /-->
     <!-- wp:comments-pagination /-->

--- a/theme.json
+++ b/theme.json
@@ -15,7 +15,7 @@
         }
       ],
       "defaultPalette": false,
-      "custom": false
+      "custom": true
     },
     "typography": {
       "fontFamilies": [


### PR DESCRIPTION
## Summary
- add CSS variables for terminal colors
- refactor CSS with `whitestudioteam_` namespaced classes
- remove inline styles from templates and parts
- prefix JS functions and update footer script
- rename WordPress enqueue functions and handles
- allow custom colors in `theme.json`

## Testing
- `npm test` *(fails: could not read `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6844c592d2ac832686990b73d55f3812