### PR TITLE
Fix body text color variable

### DIFF
--- a/style.css
+++ b/style.css
@@ -15,8 +15,8 @@ Tags: full-site-editing, block-theme, dark-mode, green-text, terminal
 */
 
 :root {
-  --whitestudioteam-bg: #000000;
-  --whitestudioteam-text: #00ff00;
+  --whitestudioteam-bg: var(--wp--style--color--background);
+  --whitestudioteam-text: var(--wp--style--color--text);
 }
 
 /* Terminal comment styling */
@@ -145,7 +145,7 @@ img {
 
 body {
   background-color: var(--whitestudioteam-bg);
-  color: #cccccc;
+  color: var(--whitestudioteam-text);
   font-family: 'Courier New', monospace;
 }
 

--- a/theme.json
+++ b/theme.json
@@ -1,6 +1,7 @@
 {
   "version": 2,
   "settings": {
+    "appearanceTools": true,
     "color": {
       "palette": [
         {


### PR DESCRIPTION
## Summary
- use the global text color variable for the body so the site editor can change it

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6845facf39008326ae97dc8318c308b3