### PR TITLE
Fix text color styling in terminal output

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,11 +14,6 @@ Text Domain: terminal-theme
 Tags: full-site-editing, block-theme, dark-mode, green-text, terminal
 */
 
-:root {
-  --whitestudioteam-bg: #000000;
-  --whitestudioteam-text: #00ff00;
-}
-
 /* Terminal comment styling */
 .wp-block-comments,
 .comment-body,
@@ -144,8 +139,10 @@ img {
 /* ========== Terminal Theme Colors ========== */
 
 body {
+  --whitestudioteam-bg: var(--wp--style--color--background);
+  --whitestudioteam-text: var(--wp--style--color--text);
   background-color: var(--whitestudioteam-bg);
-  color: #cccccc;
+  color: var(--whitestudioteam-text);
   font-family: 'Courier New', monospace;
 }
 
@@ -192,7 +189,7 @@ body {
 .terminal-output {
   white-space: pre-wrap;
   font-family: 'Courier New', monospace;
-  color: #ccc;
+  color: var(--whitestudioteam-text);
 }
 
 /* Prompt */

--- a/theme.json
+++ b/theme.json
@@ -1,6 +1,7 @@
 {
   "version": 2,
   "settings": {
+    "appearanceTools": true,
     "color": {
       "palette": [
         {


### PR DESCRIPTION
## Summary
- link body colors to global style variables so public pages reflect Site Editor changes
- apply global text color to terminal output

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845facf39008326ae97dc8318c308b3