### PR TITLE
Enable user custom colors

### DIFF
--- a/assets/css/terminal-cf7.css
+++ b/assets/css/terminal-cf7.css
@@ -1,19 +1,19 @@
 
 /* Terminal Style for Contact Form 7 */
 .wpcf7 {
-  background-color: #000;
-  color: #00ff00;
+  background-color: var(--wp--style--color--background);
+  color: var(--wp--style--color--text);
   font-family: 'Courier New', monospace;
   padding: 2rem;
-  border: 1px solid #00ff00;
+  border: 1px solid var(--wp--style--color--text);
 }
 
 .wpcf7 input[type="text"],
 .wpcf7 input[type="email"],
 .wpcf7 textarea {
-  background-color: black;
-  color: #00ff00;
-  border: 1px solid #00ff00;
+  background-color: var(--wp--style--color--background);
+  color: var(--wp--style--color--text);
+  border: 1px solid var(--wp--style--color--text);
   width: 100%;
   padding: 0.5rem;
   font-family: 'Courier New', monospace;
@@ -21,16 +21,16 @@
 }
 
 .wpcf7 input[type="submit"] {
-  background-color: black;
-  color: #00ff00;
-  border: 1px solid #00ff00;
+  background-color: var(--wp--style--color--background);
+  color: var(--wp--style--color--text);
+  border: 1px solid var(--wp--style--color--text);
   padding: 0.5rem 1rem;
   font-family: 'Courier New', monospace;
   cursor: pointer;
 }
 
 .wpcf7 input[type="submit"]:hover {
-  background-color: #00ff00;
-  color: #000;
-  border-color: #00ff00;
+  background-color: var(--wp--style--color--text);
+  color: var(--wp--style--color--background);
+  border-color: var(--wp--style--color--text);
 }

--- a/functions.php
+++ b/functions.php
@@ -1,13 +1,13 @@
 <?php
-function terminal_theme_enqueue_styles() {
+function whitestudioteam_terminal_theme_enqueue_styles() {
     wp_enqueue_style('terminal-style', get_stylesheet_directory_uri() . '/style.css', [], wp_get_theme()->get('Version'));
 }
-add_action('wp_enqueue_scripts', 'terminal_theme_enqueue_styles');
-function terminal_theme_setup() {
+add_action('wp_enqueue_scripts', 'whitestudioteam_terminal_theme_enqueue_styles');
+function whitestudioteam_terminal_theme_setup() {
     add_theme_support('editor-styles');
     add_editor_style('style.css');
 }
-add_action('after_setup_theme', 'terminal_theme_setup');
+add_action('after_setup_theme', 'whitestudioteam_terminal_theme_setup');
 
 
 add_action('init', function () {

--- a/parts/command-builder.html
+++ b/parts/command-builder.html
@@ -1,5 +1,5 @@
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="font-family:'Courier New',monospace;color:#00ff00;">
+<div class="wp-block-group" style="font-family:'Courier New',monospace;">
   <!-- wp:heading -->
   <h2>Command Builder</h2>
   <!-- /wp:heading -->
@@ -9,10 +9,10 @@
   <!-- /wp:paragraph -->
 
   <!-- wp:html -->
-  <div style="border:1px solid #00ff00;padding:1rem;margin-top:1rem;">
-    <label>Command Name:<br><input type="text" id="cmd-name" style="width:100%; background:black; color:#00ff00; border:1px solid #00ff00;" /></label><br><br>
-    <label>Command Response (HTML/Text):<br><textarea id="cmd-response" style="width:100%;height:100px;background:black;color:#00ff00;border:1px solid #00ff00;"></textarea></label><br><br>
-    <button onclick="alert('This form is a mockup — connect it to backend/plugin for saving.')" style="background:black;color:#00ff00;border:1px solid #00ff00;padding:0.5rem;">Save Command</button>
+  <div style="border:1px solid var(--wp--style--color--text);padding:1rem;margin-top:1rem;">
+    <label>Command Name:<br><input type="text" id="cmd-name" style="width:100%; background:var(--wp--style--color--background); color:var(--wp--style--color--text); border:1px solid var(--wp--style--color--text);" /></label><br><br>
+    <label>Command Response (HTML/Text):<br><textarea id="cmd-response" style="width:100%;height:100px;background:var(--wp--style--color--background);color:var(--wp--style--color--text);border:1px solid var(--wp--style--color--text);"></textarea></label><br><br>
+    <button onclick="alert('This form is a mockup — connect it to backend/plugin for saving.')" style="background:var(--wp--style--color--background);color:var(--wp--style--color--text);border:1px solid var(--wp--style--color--text);padding:0.5rem;">Save Command</button>
   </div>
   <!-- /wp:html -->
 </div>

--- a/parts/footer.html
+++ b/parts/footer.html
@@ -1,5 +1,5 @@
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="background-color:#000000;color:#00ff00;padding:1rem;text-align:center;font-family:'Courier New',monospace;">
-  <p>&copy; <script>document.write(new Date().getFullYear())</script> Built with WordPress by <a href="https://whitestudio.team" style="color:#00ff00;text-decoration:underline;" target="_blank">WhiteStudio.team</a></p>
+<div class="wp-block-group" style="padding:1rem;text-align:center;font-family:'Courier New',monospace;">
+  <p>&copy; <script>document.write(new Date().getFullYear())</script> Built with WordPress by <a href="https://whitestudio.team" style="text-decoration:underline;" target="_blank">WhiteStudio.team</a></p>
 </div>
 <!-- /wp:group -->

--- a/parts/header.html
+++ b/parts/header.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between"},"style":{"color":{"text":"#00ff00"},"spacing":{"padding":{"top":"1rem","bottom":"1rem","left":"1rem","right":"1rem"}}}} -->
+<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between"},"style":{"spacing":{"padding":{"top":"1rem","bottom":"1rem","left":"1rem","right":"1rem"}}}} -->
 <div class="wp-block-group terminal-header">
   <!-- wp:site-logo {"width":48} /-->
   <!-- wp:site-title {"level":1,"style":{"typography":{"fontSize":"1.5rem"}}} /-->

--- a/style.css
+++ b/style.css
@@ -20,9 +20,9 @@ Tags: full-site-editing, block-theme, dark-mode, green-text, terminal
 .comment-content,
 .comment-author {
   font-family: 'Courier New', monospace;
-  background: #000;
-  color: #00ff00;
-  border: 1px solid #00ff00;
+  background: var(--wp--style--color--background);
+  color: var(--wp--style--color--text);
+  border: 1px solid var(--wp--style--color--text);
   padding: 1rem;
   margin-top: 1rem;
 }
@@ -37,8 +37,8 @@ img {
    ================================ */
 
 .terminal-header {
-  background-color: #000000;
-  color: #00ff00;
+  background-color: var(--wp--style--color--background);
+  color: var(--wp--style--color--text);
   font-family: 'Courier New', monospace;
   display: flex;
   justify-content: space-between;
@@ -50,7 +50,7 @@ img {
 
 /* Site title link */
 .wp-block-site-title a {
-  color: #00ff00;
+  color: var(--wp--style--color--text);
   font-weight: bold;
   text-decoration: none;
   font-size: 1.25rem;
@@ -63,9 +63,9 @@ img {
 
 /* Search input field */
 .wp-block-search__input {
-  background-color: #000000;
+  background-color: var(--wp--style--color--background);
   border: 1px solid #444;
-  color: #00ff00;
+  color: var(--wp--style--color--text);
   padding: 0.4rem 0.6rem;
   font-family: 'Courier New', monospace;
   font-size: 0.9rem;
@@ -73,14 +73,14 @@ img {
 }
 .wp-block-search__input:focus {
   outline: none;
-  border-color: #00ff00;
-  box-shadow: 0 0 5px #00ff00;
+  border-color: var(--wp--style--color--text);
+  box-shadow: 0 0 5px var(--wp--style--color--text);
 }
 
 /* Search button */
 .wp-block-search__button {
-  background-color: #000000;
-  color: #00ff00;
+  background-color: var(--wp--style--color--background);
+  color: var(--wp--style--color--text);
   border: 1px solid #444;
   padding: 0.4rem 0.8rem;
   font-family: 'Courier New', monospace;
@@ -89,9 +89,9 @@ img {
   transition: all 0.2s ease-in-out;
 }
 .wp-block-search__button:hover {
-  background-color: #00ff00;
-  color: #000000;
-  border-color: #00ff00;
+  background-color: var(--wp--style--color--text);
+  color: var(--wp--style--color--background);
+  border-color: var(--wp--style--color--text);
 }
 
 /* Responsive: Stack on small screens */
@@ -118,8 +118,8 @@ img {
 /* ========== Terminal Theme Colors ========== */
 
 body {
-  background-color: #000000;
-  color: #cccccc;
+  background-color: var(--wp--style--color--background);
+  color: var(--wp--style--color--text);
   font-family: 'Courier New', monospace;
 }
 
@@ -132,7 +132,7 @@ body {
 
 /* Prompt */
 .terminal-prompt {
-  color: #00ff00;
+  color: var(--wp--style--color--text);
   font-weight: bold;
 }
 
@@ -157,7 +157,7 @@ body {
 
 /* Input field styling */
 #terminal-input {
-  background-color: #000000;
+  background-color: var(--wp--style--color--background);
   border: none;
   color: #aaaaaa;
   font-family: 'Courier New', monospace;

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="background-color:#000000;color:#00ff00;font-family:'Courier New',monospace;padding:2rem;">
+<div class="wp-block-group" style="font-family:'Courier New',monospace;padding:2rem;">
   <!-- wp:query-title {"type":"archive"} /-->
 
   <!-- wp:query {"queryId":0,"query":{"perPage":5,"pages":0,"offset":0,"postType":"post"},"displayLayout":{"type":"list"},"tagName":"div"} -->

--- a/templates/front-page.html
+++ b/templates/front-page.html
@@ -1,14 +1,14 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group test-front-page" style="background-color:#000000;color:#00ff00;font-family:'Courier New',monospace;padding:2rem;">
+<div class="wp-block-group test-front-page" style="font-family:'Courier New',monospace;padding:2rem;">
   <p><strong>user@terminal:</strong>~$ Type <code>help</code> to list available commands</p>
 
   <div class="terminal-output" id="terminal-output" style="white-space: pre-wrap;"></div>
 
  <p style="display:flex;align-items:center;">
   <strong>user@terminal:</strong>~$
-  <input id="terminal-input" type="text" autocomplete="off" style="background:none;border:none;color:#00ff00;width:90%; margin:0px 5px" placeholder="Type command..." />
+  <input id="terminal-input" type="text" autocomplete="off" style="background:none;border:none;width:90%; margin:0px 5px" placeholder="Type command..." />
 </p>
 </div>
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/page.html
+++ b/templates/page.html
@@ -6,13 +6,13 @@ img {
 }
 img:hover {
   filter: none;
-  box-shadow: 0 0 10px #00ff00;
+  box-shadow: 0 0 10px var(--wp--style--color--text);
 }
 </style>
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group test-page" style="background-color:#000000;color:#00ff00;font-family:'Courier New',monospace;padding:2rem;">
+<div class="wp-block-group test-page" style="font-family:'Courier New',monospace;padding:2rem;">
   <!-- wp:post-title /-->
   <!-- wp:post-content /-->
 </div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="background-color:#000000;color:#00ff00;font-family:'Courier New',monospace;padding:2rem;">
+<div class="wp-block-group" style="font-family:'Courier New',monospace;padding:2rem;">
 
   <!-- Search Form -->
   <!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search"} /-->

--- a/templates/single.html
+++ b/templates/single.html
@@ -1,18 +1,8 @@
 
-<style>
-.comment-body, .comment-author, .comment-content {
-  font-family: 'Courier New', monospace;
-  background-color: black;
-  color: #00ff00;
-  border: 1px solid #00ff00;
-  padding: 0.5rem;
-  margin-bottom: 1rem;
-}
-</style>
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="background-color:#000000;color:#00ff00;font-family:'Courier New',monospace;padding:2rem;">
+<div class="wp-block-group" style="font-family:'Courier New',monospace;padding:2rem;">
   <!-- wp:post-title /-->
   <!-- wp:post-content /-->
 

--- a/theme.json
+++ b/theme.json
@@ -14,9 +14,10 @@
           "name": "Terminal Green"
         }
       ],
-      "defaultPalette": false,
-      "custom": false
+      "defaultPalette": true,
+      "custom": true
     },
+    "appearanceTools": true,
     "typography": {
       "fontFamilies": [
         {


### PR DESCRIPTION
## Summary
- remove inline color styles so global styles control background/text colors
- update comment styles to use global color variables
- convert CF7 styles to use global color variables
- enable FSE appearance tools

## Testing
- `php -l functions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68475fb8d6dc832698a51632c7e43e53